### PR TITLE
adds missing gradle tooling events to jar

### DIFF
--- a/cli/bnd.bnd
+++ b/cli/bnd.bnd
@@ -90,8 +90,12 @@ Private-Package:\
 	org.gradle.scripts;-split-package:=merge-first,\
 	org.gradle.tooling;-split-package:=merge-first,\
 	org.gradle.tooling.events;-split-package:=merge-first,\
+	org.gradle.tooling.events.configuration;-split-package:=merge-first,\
 	org.gradle.tooling.events.task;-split-package:=merge-first,\
+	org.gradle.tooling.events.task.java;-split-package:=merge-first,\
 	org.gradle.tooling.events.test;-split-package:=merge-first,\
+	org.gradle.tooling.events.transform;-split-package:=merge-first,\
+	org.gradle.tooling.events.work;-split-package:=merge-first,\
 	org.gradle.tooling.exceptions;-split-package:=merge-first,\
 	org.gradle.tooling.internal.adapter;-split-package:=merge-first,\
 	org.gradle.tooling.internal.consumer;-split-package:=merge-first,\


### PR DESCRIPTION
Fixes the following:

```sh
$ blade extension install .
org/gradle/tooling/events/work/WorkItemProgressEvent
java.lang.NoClassDefFoundError: org/gradle/tooling/events/work/WorkItemProgressEvent
	at org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters.<init>(ConsumerOperationParameters.java:278)
	at org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters.<init>(ConsumerOperationParameters.java:50)
	at org.gradle.tooling.internal.consumer.parameters.ConsumerOperationParameters$Builder.build(ConsumerOperationParameters.java:209)
	at org.gradle.tooling.internal.consumer.AbstractLongRunningOperation.getConsumerOperationParameters(AbstractLongRunningOperation.java:52)
	at org.gradle.tooling.internal.consumer.DefaultModelBuilder.get(DefaultModelBuilder.java:56)
	at org.gradle.tooling.internal.consumer.DefaultModelBuilder.get(DefaultModelBuilder.java:50)
	at com.liferay.blade.cli.gradle.GradleTooling.loadProjectInfo(GradleTooling.java:80)
	at com.liferay.blade.cli.command.InstallExtensionCommand._gradleAssemble(InstallExtensionCommand.java:337)
	at com.liferay.blade.cli.command.InstallExtensionCommand.execute(InstallExtensionCommand.java:245)
	at com.liferay.blade.cli.BladeCLI._runCommand(BladeCLI.java:1188)
	at com.liferay.blade.cli.BladeCLI.runCommand(BladeCLI.java:591)
	at com.liferay.blade.cli.BladeCLI.run(BladeCLI.java:435)
	at com.liferay.blade.cli.BladeCLI.main(BladeCLI.java:131)
Caused by: java.lang.ClassNotFoundException: org.gradle.tooling.events.work.WorkItemProgressEvent
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 13 more
```