### PR TITLE
BLADE-685 update to latest 5.0.213 project template

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
 	compile group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "4.3.0"
 	compile group: "com.liferay", name: "com.liferay.gogo.shell.client", version: "1.0.0"
-	compile group: "com.liferay", name: "com.liferay.project.templates", version: "5.0.211"
+	compile group: "com.liferay", name: "com.liferay.project.templates", version: "5.0.213"
 	compile group: "commons-io", name: "commons-io", version: "2.6"
 	compile group: "org.apache.ant", name: "ant", version: "1.10.7"
 	compile group: "commons-lang", name: "commons-lang", version: "2.6"


### PR DESCRIPTION
The 5.0.213 project template contains the fix of rest-builder project compile problem.