### PR TITLE
BLADE-750 Blade throws an exception when releases.json contains extra fields

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -55,6 +55,7 @@ clean.doFirst {
 }
 
 cliSourcesJar {
+	dependsOn "unzipPortal"
 	archiveClassifier.set("sources")
 	from sourceSets.main.allJava
 }


### PR DESCRIPTION
This is an update for [BLADE-750](https://liferay.atlassian.net/browse/BLADE-750).
