### PR TITLE
LPD-49398 JCommander usage update and LPD-49543 project-templates version update

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 	api group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "5.3.0"
 	api group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.16.1"
 	api group: "com.liferay", name: "com.liferay.gogo.shell.client", version: "1.0.0"
-	api group: "com.liferay", name: "com.liferay.project.templates", version: "5.1.2"
+	api group: "com.liferay", name: "com.liferay.project.templates", version: "5.1.6"
 	api group: "com.liferay", name: "com.liferay.release.util", version: "1.0.0"
 	api group: "commons-io", name: "commons-io", version: "2.7"
 	api group: "commons-lang", name: "commons-lang", version: "2.6"

--- a/cli/src/main/java/com/liferay/blade/cli/BladeCLI.java
+++ b/cli/src/main/java/com/liferay/blade/cli/BladeCLI.java
@@ -364,7 +364,10 @@ public class BladeCLI {
 			jCommander.addCommand(baseArgs);
 		}
 
-		jCommander.usage(sb);
+		jCommander.getUsageFormatter(
+		).usage(
+			sb
+		);
 
 		try (Scanner scanner = new Scanner(sb.toString())) {
 			StringBuilder simplifiedUsageString = new StringBuilder();
@@ -396,13 +399,19 @@ public class BladeCLI {
 	}
 
 	public void printUsage(String command) {
-		_jCommander.usage(command);
+		_jCommander.getUsageFormatter(
+		).usage(
+			command
+		);
 	}
 
 	public void printUsage(String command, String message) {
 		out(message);
 
-		_jCommander.usage(command);
+		_jCommander.getUsageFormatter(
+		).usage(
+			command
+		);
 	}
 
 	public void run(String[] args) throws Exception {


### PR DESCRIPTION
Update for [LPD-49398](https://liferay.atlassian.net/browse/LPD-49398) and [LPD-49543](https://liferay.atlassian.net/browse/LPD-49543)

JCommander was updated to version 1.82 across our code so the jCommander.usage method calls had to be updated to jCommander.getUsageFormatter calls. 

Related to LPD-49398 the project-templates version was updated as well. 