### PR TITLE
LPD-96463 prepareSnapshot

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -121,10 +121,10 @@ dependencies {
 	api name: "org.objectweb.asm.commons-6.0.0"
 	api name: "org.objectweb.asm.tree-6.0.0"
 	api name: "org.objectweb.asm.util-6.0.0"
-	bladeExtensions group: "com.liferay.blade", name: "com.liferay.blade.extensions.maven.profile", version: "1.0.47"
-	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.js.theme", version: "1.0.30"
-	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.js.widget", version: "1.0.31"
-	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.npm.angular.portlet", version: "1.0.199"
+	bladeExtensions group: "com.liferay.blade", name: "com.liferay.blade.extensions.maven.profile", version: "1.0.48-SNAPSHOT"
+	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.js.theme", version: "1.0.31-SNAPSHOT"
+	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.js.widget", version: "1.0.32-SNAPSHOT"
+	bladeExtensions group: "com.liferay.blade", name: "com.liferay.project.templates.npm.angular.portlet", version: "1.0.200-SNAPSHOT"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":gradle-tooling")
 	testImplementation gradleTestKit()
@@ -331,6 +331,6 @@ unzipPortal {
 	finalizedBy("processZipsResources")
 }
 
-version = "8.0.2"
+version = "8.0.3-SNAPSHOT"
 
 apply from: "blade-jar-smoke-tests.gradle"

--- a/extensions/maven-profile/build.gradle
+++ b/extensions/maven-profile/build.gradle
@@ -43,4 +43,4 @@ publishing {
 	}
 }
 
-version = "1.0.47"
+version = "1.0.48-SNAPSHOT"

--- a/extensions/project-templates-js-theme/build.gradle
+++ b/extensions/project-templates-js-theme/build.gradle
@@ -58,4 +58,4 @@ test {
 	}
 }
 
-version = "1.0.30"
+version = "1.0.31-SNAPSHOT"

--- a/extensions/project-templates-js-widget/build.gradle
+++ b/extensions/project-templates-js-widget/build.gradle
@@ -56,4 +56,4 @@ test {
 	}
 }
 
-version = "1.0.31"
+version = "1.0.32-SNAPSHOT"

--- a/extensions/project-templates-npm-angular-portlet/build.gradle
+++ b/extensions/project-templates-npm-angular-portlet/build.gradle
@@ -46,4 +46,4 @@ publishing {
 	}
 }
 
-version = "1.0.199"
+version = "1.0.200-SNAPSHOT"

--- a/extensions/project-templates-social-bookmark/build.gradle
+++ b/extensions/project-templates-social-bookmark/build.gradle
@@ -59,4 +59,4 @@ publishing {
 	}
 }
 
-version = "1.0.28"
+version = "1.0.29-SNAPSHOT"

--- a/extensions/remote-deploy-command/build.gradle
+++ b/extensions/remote-deploy-command/build.gradle
@@ -36,4 +36,4 @@ publishing {
 	}
 }
 
-version = "1.0.38"
+version = "1.0.39-SNAPSHOT"

--- a/gradle-tooling/build.gradle
+++ b/gradle-tooling/build.gradle
@@ -17,4 +17,4 @@ publishing {
 }
 */
 
-version = "1.2.31"
+version = "1.2.32-SNAPSHOT"


### PR DESCRIPTION
Prepare snapshot versions following the 8.0.2 release.

Bumps each module to the next patch `-SNAPSHOT` version and updates the matching `bladeExtensions` dependency versions in `cli/build.gradle`:

| Module | Before | After |
|--------|--------|-------|
| cli | 8.0.2 | 8.0.3-SNAPSHOT |
| maven-profile | 1.0.47 | 1.0.48-SNAPSHOT |
| project-templates-js-theme | 1.0.30 | 1.0.31-SNAPSHOT |
| project-templates-js-widget | 1.0.31 | 1.0.32-SNAPSHOT |
| project-templates-npm-angular-portlet | 1.0.199 | 1.0.200-SNAPSHOT |
| project-templates-social-bookmark | 1.0.28 | 1.0.29-SNAPSHOT |
| remote-deploy-command | 1.0.38 | 1.0.39-SNAPSHOT |
| gradle-tooling | 1.2.31 | 1.2.32-SNAPSHOT |

Generated by `./gradlew prepareSnapshot`.